### PR TITLE
change destination URI for tracker

### DIFF
--- a/lib/cfg.d/pirus.pl
+++ b/lib/cfg.d/pirus.pl
@@ -69,7 +69,7 @@ require LWP::UserAgent;
 require LWP::ConnCache;
 
 # modify the following URL to the PIRUS tracker location
-$c->{pirus}->{tracker} = "http://www.jusp.mimas.ac.uk/counter/";
+$c->{pirus}->{tracker} = "http://jusp.jisc.ac.uk/counter/";
 
 # you may want to revise the settings for the user agent e.g. increase or
 # decrease the network timeout


### PR DESCRIPTION
tracker no longer needs to go via mimas, but should go straight to jusp.jisc.ac.uk/counter/