### PR TITLE
Fix replay job to work as advertised

### DIFF
--- a/lib/cfg.d/pirus.pl
+++ b/lib/cfg.d/pirus.pl
@@ -89,7 +89,7 @@ $c->add_dataset_trigger( 'access', EPrints::Const::EP_TRIGGER_CREATED, sub {
 	if( defined $r && !$r->is_success )
 	{
 		my $fail_message = "PIRUS dataset trigger failed to send data to tracker.\n " . $r->as_string;
-		my $event = $repo->dataset( "event_queue" )->dataobj_class->create_unique( $repo, {
+		my $event = EPrints::DataObj::EventQueue->create_unique( $repo, {
 			pluginid    => "Event::PIRUS",
 			action      => "replay",
 			params      => [ $access->id, $request_url ],

--- a/lib/plugins/EPrints/Plugin/Event/PIRUS.pm
+++ b/lib/plugins/EPrints/Plugin/Event/PIRUS.pm
@@ -131,11 +131,7 @@ sub log
 	else { return; }
 
 	# rfr_dat
-	if ( $access->is_set("referring_entity_id") )
-	{
-		$qf_params{rfr_dat} = $access->value("referring_entity_id");
-	}
-	else { return; }
+	$qf_params{rfr_dat} = $access->value("referring_entity_id") // q();
 
 	# rfr_id
 	$qf_params{rfr_id} =

--- a/lib/plugins/EPrints/Plugin/Event/PIRUS.pm
+++ b/lib/plugins/EPrints/Plugin/Event/PIRUS.pm
@@ -9,7 +9,7 @@ use strict;
 # @jesusbagpuss
 # Counter v5 - send data about abstract page views (invesitgations) as well as downloads
 
-# borrowed from EPrints 3.3's EPrints::OpenArchives::archive_id
+# borrowed from EPrints 3.4's EPrints::OpenArchives::archive_id
 sub _archive_id
 {
 	my( $repo, $any ) = @_;
@@ -18,6 +18,7 @@ sub _archive_id
 	my $v2 = $repo->config( "oai", "v2", "archive_id" );
 
 	$v1 ||= $repo->config( "host" );
+	$v1 ||= $repo->config("securehost");
 	$v2 ||= $v1;
 
 	return $any ? ($v1, $v2) : $v2;

--- a/lib/plugins/EPrints/Plugin/Event/PIRUS.pm
+++ b/lib/plugins/EPrints/Plugin/Event/PIRUS.pm
@@ -50,8 +50,10 @@ sub replay
 
 	# Reschedule the event:
 	my $event = $self->{event};
-	$event->set_value( "params", [$accessid, $request_url] );
-	$event->set_value( "start_time", EPrints::Time::iso_datetime( time + 86400 ) );
+	$start_time = time() + (24 * 60 * 60);   # try again in 24 hours time
+	$event->set_value( "start_time",
+		EPrints::Time::iso_datetime( $start_time )
+	);
 	$event->set_value( "description", $fail_message );
 
 	# Set status to 'waiting' and commit:


### PR DESCRIPTION
This PR fixes several problems with the implementation:

- The URL being requested (`$request_url`) is a required part of the ping to IRUS (`svc_dat`), but is not available to the `replay` job (it is not recorded in the Access instance). This PR adds it as a parameter to the job so it can be passed on to `PIRUS::log`.
- Access instances can be populated with NULL values; such instances should not be turned into pings. This PR allows such instances to be disregarded silently.
- If the ping fails again during the `replay` job, the steps are taken to reschedule the job for 24 hours' time, and this is reported in the error message. However, the job then returns a `0` value, which causes `EPrints::DataObj::EventQueue::execute` to log an additional error and then delete the job; so the ping is not in fact retried. This PR restores the HTTP_RESET_CONTENT return value that allows the job to be retried.
- The `_archive_id` method is out of sync with `EPrints::OpenArchives::archive_id`, since it does not fall back to `securehost`.

NB. I have also simplified the idioms used for loading an Access instance and creating the `replay` job. These work for EPrints v3.3+ but I don't have access to the source code for v3.2 to be able to check compatibility there.